### PR TITLE
chore: set default node home to $HOME/.oraid

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -167,7 +167,7 @@ func GetEnabledProposals() []wasm.ProposalType {
 // any overrides above
 var (
 	// DefaultNodeHome default home directories for wasmd
-	DefaultNodeHome = os.ExpandEnv("$PWD/") + NodeDir
+	DefaultNodeHome = os.ExpandEnv("$HOME/") + NodeDir
 
 	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address
 	Bech32PrefixAccAddr = appconfig.Bech32Prefix


### PR DESCRIPTION
Hello,

It's really annoying to have the NodeHome in $PWD/.oraid by default for multiple reasons.

- Everytime you execute a `oraid` command, you'll create a new `$PWD/.oraid`
- If you're in `/` default is `//.oraid`

For the docker images, i believe we might need to fix and set the home directory to `/workspace` or change the default location to `/root/.oraid` ?